### PR TITLE
Update PDFViewerDemo's dependencies

### DIFF
--- a/PDFViewerDemo/MainWindow.axaml.cs
+++ b/PDFViewerDemo/MainWindow.axaml.cs
@@ -212,13 +212,13 @@ namespace PDFViewerDemo
 
             gpr.Restore();
 
-            gpr.FillText(400, 92, "Move the mouse with", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
-            gpr.FillText(400, 148, "the left button pressed", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
-            gpr.FillText(400, 204, "to pan around or to", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
-            gpr.FillText(400, 260, "select text", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 92, "Move the mouse with", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 148, "the left button pressed", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 204, "to pan around or to", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 260, "select text", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
 
-            gpr.FillText(400, 530, "Use the mouse wheel", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
-            gpr.FillText(400, 586, "to zoom in/out", new VectSharp.Font(new VectSharp.FontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 530, "Use the mouse wheel", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
+            gpr.FillText(400, 586, "to zoom in/out", new VectSharp.Font(VectSharp.FontFamily.ResolveFontFamily(VectSharp.FontFamily.StandardFontFamilies.HelveticaBold), 35), VectSharp.Colours.Gray);
 
             MemoryStream ms = new MemoryStream();
             doc.SaveAsPDF(ms);

--- a/PDFViewerDemo/PDFViewerDemo.csproj
+++ b/PDFViewerDemo/PDFViewerDemo.csproj
@@ -10,11 +10,11 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.10" />
-    <PackageReference Include="HarfBuzzSharp" Version="2.8.2-preview.155" />
+    <PackageReference Include="Avalonia" Version="0.10.18" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.8.2.1" />
     <PackageReference Include="MuPDFCore.MuPDFRenderer" Version="1.6.0" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.155" />
-    <PackageReference Include="VectSharp.PDF" Version="2.2.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.1" />
+    <PackageReference Include="VectSharp.PDF" Version="2.5.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
mainly bump VectSharp from 2.2.x -> 2.5.x
other version bumps are minor ones.

fix a minor breakage according to your obsolete note.

works on my machine.